### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_script:
 - cd $TRAVIS_BUILD_DIR/..
 - git clone https://github.com/trummerjo/xbmc.git
 - cd xbmc
-- git checkout c8473d566dea62a8e7aed7076f9f0860117fbff9
 - cd ..
 - cd pvr.zattoo && mkdir build && cd build
 - cmake -DADDONS_TO_BUILD=pvr.zattoo -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DCMAKE_BUILD_TYPE=Debug

--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.zattoo"
-  version="0.0.3"
+  version="0.1.0"
   name="Zattoo PVR Client"
   provider-name="Johannes Trum">
   <extension

--- a/pvr.zattoo/changelog.txt
+++ b/pvr.zattoo/changelog.txt
@@ -1,3 +1,5 @@
+v0.1.0
+ - Support Kodi v17
 v0.0.3
  - Favoriten werden nun geladen
  - Es werden nun so viele EPG Daten im vorraus geladen wie in Kodi eingestellt


### PR DESCRIPTION
My suggestion is to keep 0.0.\* for possible Jarvis builds.
