### PR TITLE
Fix favourites sorting

### DIFF
--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.zattoo"
-  version="0.1.4"
+  version="0.1.5"
   name="Zattoo PVR Client"
   provider-name="Johannes Trum">
   <extension

--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.zattoo"
-  version="0.1.1"
+  version="0.1.2"
   name="Zattoo PVR Client"
   provider-name="Johannes Trum">
   <extension

--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.zattoo"
-  version="0.1.3"
+  version="0.1.4"
   name="Zattoo PVR Client"
   provider-name="Johannes Trum">
   <extension

--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.zattoo"
-  version="0.1.2"
+  version="0.1.3"
   name="Zattoo PVR Client"
   provider-name="Johannes Trum">
   <extension

--- a/pvr.zattoo/changelog.txt
+++ b/pvr.zattoo/changelog.txt
@@ -1,3 +1,5 @@
+v0.1.2
+ - Support watching recordings
 v0.1.1
  - Replace own HTTP implementation with Curl from Kodi
 v0.1.0

--- a/pvr.zattoo/changelog.txt
+++ b/pvr.zattoo/changelog.txt
@@ -1,3 +1,6 @@
+v0.1.4
+ - Support deletion of timer (planned recording)
+ - Refresh timers after change 
 v0.1.3
  - Support creating timers (for recordings)
  - Support deletion of recordings

--- a/pvr.zattoo/changelog.txt
+++ b/pvr.zattoo/changelog.txt
@@ -1,3 +1,6 @@
+v0.1.3
+ - Support creating timers (for recordings)
+ - Support deletion of recordings
 v0.1.2
  - Support watching recordings
 v0.1.1

--- a/pvr.zattoo/changelog.txt
+++ b/pvr.zattoo/changelog.txt
@@ -1,3 +1,6 @@
+v0.1.5
+ - Fix sorting of favourites by using the first n channel numbers for them
+ - Offset the remaining channels by the number of favourites to prevent overlaps
 v0.1.4
  - Support deletion of timer (planned recording)
  - Refresh timers after change 

--- a/src/JsonParser.cpp
+++ b/src/JsonParser.cpp
@@ -51,6 +51,22 @@ string JsonParser::getString(yajl_val json, int path_len, ...) {
 	return str;
 }
 
+time_t JsonParser::getTime(yajl_val json, int path_len, ...) {
+  va_list args;
+    va_start(args, path_len);
+    const char **path = getPath(path_len, args);
+  char *str = YAJL_GET_STRING(yajl_tree_get(json, path, yajl_t_string));
+  va_end(args);
+  delete [] path;
+  if (str == NULL) {
+    return 0;
+  }
+  struct tm tm;
+  strptime(str, "%Y-%m-%dT%H:%M:%SZ", &tm);
+  time_t t = mktime(&tm);
+  return t;
+}
+
 int JsonParser::getInt(yajl_val json, int path_len, ...) {
 	va_list args;
     va_start(args, path_len);

--- a/src/JsonParser.cpp
+++ b/src/JsonParser.cpp
@@ -63,7 +63,7 @@ time_t JsonParser::getTime(yajl_val json, int path_len, ...) {
   }
   struct tm tm;
   strptime(str, "%Y-%m-%dT%H:%M:%SZ", &tm);
-  time_t t = mktime(&tm);
+  time_t t = timegm(&tm);
   return t;
 }
 

--- a/src/JsonParser.h
+++ b/src/JsonParser.h
@@ -1,6 +1,7 @@
 #include "yajl/yajl_tree.h"
 #include <iostream>
 #include <stdarg.h>
+#include <time.h>
 
 using namespace std;
 
@@ -10,6 +11,7 @@ public:
 	static yajl_val parse(string jsonString);
 	static bool getBoolean(yajl_val json, int path_len, ...);
 	static string getString(yajl_val json, int path_len, ...);
+	static time_t getTime(yajl_val json, int path_len, ...);
 	static int getInt(yajl_val json, int path_len, ...);
 	static yajl_val getArray(yajl_val json, int path_len, ...);
 private:

--- a/src/ZatData.h
+++ b/src/ZatData.h
@@ -87,6 +87,8 @@ public:
     virtual void GetRecordings(ADDON_HANDLE handle);
     virtual int GetRecordingsAmount();
     virtual std::string GetRecordingStreamUrl(string recordingId);
+    virtual bool Record(int programId);
+    virtual bool DeleteRecording(string recordingId);
 
 protected:
     virtual std::string Base64Encode(unsigned char const* in, unsigned int in_len, bool urlEncode);

--- a/src/ZatData.h
+++ b/src/ZatData.h
@@ -72,6 +72,7 @@ public:
     ZatData(std::string username, std::string password);
     virtual ~ZatData();
 
+    virtual void      GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities);
     virtual int       GetChannelsAmount(void);
     virtual PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
     //virtual bool      GetChannel(const PVR_CHANNEL &channel, ZatChannel &myChannel);
@@ -84,8 +85,8 @@ public:
     //    virtual void      ReloadPlayList(const char * strNewPath);
     //    virtual void      ReloadEPG(const char * strNewPath);
     virtual std::string GetChannelStreamUrl(int uniqueId);
-    virtual void GetRecordings(ADDON_HANDLE handle);
-    virtual int GetRecordingsAmount();
+    virtual void GetRecordings(ADDON_HANDLE handle, bool future);
+    virtual int GetRecordingsAmount(bool future);
     virtual std::string GetRecordingStreamUrl(string recordingId);
     virtual bool Record(int programId);
     virtual bool DeleteRecording(string recordingId);
@@ -94,7 +95,6 @@ protected:
     virtual std::string Base64Encode(unsigned char const* in, unsigned int in_len, bool urlEncode);
     virtual std::string HttpGet(string url);
     virtual std::string HttpPost(string url, string postData);
-    virtual void loadAppId();
 
     virtual bool                 LoadEPG(time_t iStart, time_t iEnd);
 
@@ -114,12 +114,12 @@ private:
     int                               channelNumber;
     std::string                       appToken;
     std::string                       powerHash;
+    bool                              recallEnabled;
+    bool                              recordingEnabled;
     std::string                       username;
     std::string                       password;
     std::string                       m_strLogoPath;
     std::vector<PVRZattooChannelGroup> channelGroups;
-
-    void sendHello();
 
     bool login();
 

--- a/src/ZatData.h
+++ b/src/ZatData.h
@@ -5,6 +5,12 @@
 #include "client.h"
 #include "JsonParser.h"
 
+/*!
+ * @brief PVR macros for string exchange
+ */
+#define PVR_STRCPY(dest, source) do { strncpy(dest, source, sizeof(dest)-1); dest[sizeof(dest)-1] = '\0'; } while(0)
+#define PVR_STRCLR(dest) memset(dest, 0, sizeof(dest))
+
 struct PVRIptvEpgEntry
 {
     int         iBroadcastId;
@@ -78,36 +84,21 @@ public:
     //    virtual void      ReloadPlayList(const char * strNewPath);
     //    virtual void      ReloadEPG(const char * strNewPath);
     virtual std::string GetChannelStreamUrl(int uniqueId);
+    virtual void GetRecordings(ADDON_HANDLE handle);
+    virtual int GetRecordingsAmount();
+    virtual std::string GetRecordingStreamUrl(string recordingId);
+
 protected:
     virtual std::string Base64Encode(unsigned char const* in, unsigned int in_len, bool urlEncode);
     virtual std::string HttpGet(string url);
     virtual std::string HttpPost(string url, string postData);
     virtual void loadAppId();
 
-
-
-
-//
-//    virtual bool                 LoadPlayList(void);
     virtual bool                 LoadEPG(time_t iStart, time_t iEnd);
-//    virtual bool                 LoadGenres(void);
-
-
 
     virtual ZatChannel*      FindChannel(int uniqueId);
     virtual PVRZattooChannelGroup* FindGroup(const std::string &strName);
 
-
-//    virtual PVRIptvEpgChannel*   FindEpg(const std::string &strId);
-//    virtual PVRIptvEpgChannel*   FindEpgForChannel(ZatChannel &channel);
-//    virtual bool                 FindEpgGenre(const std::string& strGenre, int& iType, int& iSubType);
-//    virtual int                  ParseDateTime(std::string& strDate, bool iDateFormat = true);
-//    virtual bool                 GzipInflate( const std::string &compressedBytes, std::string &uncompressedBytes);
-//    virtual int                  GetCachedFileContents(const std::string &strCachedName, const std::string &strFilePath,
-//                                                       std::string &strContent, const bool bUseCache = false);
-//    virtual void                 ApplyChannelsLogos();
-//    virtual void                 ApplyChannelsLogosFromEPG();
-//    virtual std::string          ReadMarkerValue(std::string &strLine, const char * strMarkerName);
     virtual int                  GetChannelId(const char * strChannelName);
 
 protected:

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -201,6 +201,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bSupportsRadio           = true;
   pCapabilities->bSupportsChannelGroups   = true;
   pCapabilities->bSupportsRecordings      = true;
+  pCapabilities->bSupportsTimers          = true;
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -355,6 +356,31 @@ PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted) {
   return PVR_ERROR_NO_ERROR;
 }
 
+PVR_ERROR AddTimer(const PVR_TIMER &timer) {
+  if (!zat) {
+    return PVR_ERROR_SERVER_ERROR;
+  }
+  if (timer.iEpgUid <= EPG_TAG_INVALID_UID) {
+    return PVR_ERROR_REJECTED;
+  }
+  if (!zat->Record(timer.iEpgUid)) {
+    return PVR_ERROR_REJECTED;
+  }
+  return PVR_ERROR_NO_ERROR;
+}
+
+PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) {
+  if (!zat) {
+    return PVR_ERROR_SERVER_ERROR;
+  }
+  if (!zat->DeleteRecording(recording.strRecordingId)) {
+    return PVR_ERROR_REJECTED;
+  }
+  return PVR_ERROR_NO_ERROR;
+}
+
+
+
 /** UNUSED API FUNCTIONS */
 bool CanPauseStream(void) { return false; }
 PVR_ERROR OpenDialogChannelScan(void) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -376,7 +402,6 @@ int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize) { return 0;
 long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { return -1; }
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
-PVR_ERROR DeleteRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameRecording(const PVR_RECORDING &recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -385,7 +410,6 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return 
 PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size) { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(ADDON_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -200,7 +200,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bSupportsTV              = true;
   pCapabilities->bSupportsRadio           = true;
   pCapabilities->bSupportsChannelGroups   = true;
-  pCapabilities->bSupportsRecordings      = false;
+  pCapabilities->bSupportsRecordings      = true;
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -333,11 +333,30 @@ const char * GetLiveStreamURL(const PVR_CHANNEL &channel)  {
     return XBMC->UnknownToUTF8(zat->GetChannelStreamUrl(channel.iUniqueId).c_str());
 }
 
+/** Recording API **/
+int GetRecordingsAmount(bool deleted) {
+  if (deleted) {
+    return 0;
+  }
+  if (!zat) {
+    return 0;
+  }
+  return zat->GetRecordingsAmount();
+}
+
+PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted) {
+  if (deleted) {
+    return PVR_ERROR_NO_ERROR;
+  }
+  if (!zat) {
+    return PVR_ERROR_SERVER_ERROR;
+  }
+  zat->GetRecordings(handle);
+  return PVR_ERROR_NO_ERROR;
+}
 
 /** UNUSED API FUNCTIONS */
 bool CanPauseStream(void) { return false; }
-int GetRecordingsAmount(bool deleted) { return -1; }
-PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR OpenDialogChannelScan(void) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }


### PR DESCRIPTION
I did not find a better way to fix the order other than changing the channel number. Now the favourites start with 1 and the remaining channels at [number_of_favourites] + 1

This PR does also contain the recordings branch (to prevent merge conflicts due to the version increment)
