### PR TITLE
Requires "xbmc.pvr" version 5.2.1 via c-pluff version 0.1 as imported…

### DIFF
--- a/pvr.zattoo/addon.xml.in
+++ b/pvr.zattoo/addon.xml.in
@@ -4,6 +4,10 @@
   version="0.1.23"
   name="Zattoo PVR Client"
   provider-name="trummerjo,rbuehlma">
+  <requires>
+    <c-pluff version="0.1"/>
+    <import addon="xbmc.pvr" version="5.2.1"/>
+  </requires>
   <extension
     point="xbmc.pvrclient"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>


### PR DESCRIPTION
… addon

Does this Zattoo PVR Client add-on not require to import addon "xbmc.pvr" version 5.2.1 via c-pluff 0.1 as other do?

Same as pvr.iptvsimple https://github.com/kodi-pvr/pvr.iptvsimple/blob/master/pvr.iptvsimple/addon.xml.in